### PR TITLE
BDK traits and essence - weight fixes

### DIFF
--- a/Data.lua
+++ b/Data.lua
@@ -5383,19 +5383,20 @@ do
 			-- Iterations: 7098 - 10128 (avg 7675), Target Error: 0.05, Fight Length: 240 - 360, Fight Style: Patchwerk
 			-- Updated: 03.08.2019, Metric: Theck-Meloree-Index,  Scaling: Linear 0 - 10, Precision: 2
 			[560] = 2.25, -- Bonded Souls
-			[243] = 9.7, -- Bloody Runeblade
+			[243] = 2.50, -- Bloody Runeblade
 			[481] = 5.85, -- Incite the Pack
 			[196] = 3.81, -- Swirling Sands
 			[193] = 4.12, -- Blightborne Infusion
 			[461] = 0.72, -- Earthlink
 			[496] = 1.05, -- Stronger Together
 			[43] = 0.11, -- Winds of War
-			[349] = 4.81, -- Bones of the Damned
-			[197] = 7.06, -- Marrowblood
+			[83] = 10, -- Impassive Visage
+			[349] = 1.00, -- Bones of the Damned
+			[197] = 0.30, -- Marrowblood
 			[495] = 1.99, -- Anduin's Dedication
 			[82] = 6.03, -- Champion of Azeroth
 			[15] = 10, -- Resounding Protection
-			[348] = 4.02, -- Eternal Rune Weapon
+			[348] = 2.00, -- Eternal Rune Weapon
 			[18] = 5.65, -- Blood Siphon
 			[526] = 3.6, -- Endless Hunger
 			[577] = 0.92, -- Arcane Heart
@@ -5416,7 +5417,7 @@ do
 			[480] = 3.98, -- Blood Rite
 			[140] = 2.69, -- Bone Spike Graveyard
 			[485] = 0.06, -- Laser Matrix
-			[44] = 0.07, -- Vampiric Speed
+			[44] = 3.00, -- Vampiric Speed
 			[498] = 0.08, -- Barrage Of Many Bombs
 			[19] = 0.06, -- Woundbinder
 			[504] = 2.8, -- Unstable Catalyst

--- a/Data.lua
+++ b/Data.lua
@@ -5435,15 +5435,16 @@ do
 			-- SimulationCraft 820-02 for World of Warcraft 8.2.0 Live (wow build 30918)
 			-- Iterations: 6865 - 7777 (avg 7389), Target Error: 0.05, Fight Length: 240 - 360, Fight Style: Patchwerk
 			-- Updated: 03.08.2019, Metric: Theck-Meloree-Index,  Scaling: Linear 0 - 10, Precision: 2
-			[32] = { 0.71, 0.87 }, -- Conflict and Strife
-			[3] = { 3.15, 3.26 }, -- Sphere of Suppression
-			[7] = { 3.8, 3.69 }, -- Anima of Life and Death
+			[32] = { 0.71, 3.70 }, -- Conflict and Strife
+			[3] = { 1.20, 0.50 }, -- Sphere of Suppression
+			[7] = { 0.70, 0.30 }, -- Anima of Life and Death
 			[4] = { 0.69, 0.48 }, -- Worldvein Resonance
-			[25] = { 0.36, 0.21 }, -- Aegis of the Deep
-			[2] = { 0, 0.03 }, -- Azeroth's Undying Gift
-			[22] = { 0.97, 0 }, -- Vision of Perfection
+			[25] = { 0.36, 2.50 }, -- Aegis of the Deep
+			[12] = { 3.00, 1.70 }, -- The Crucible of Flame
+			[2] = { 1.20, 0.03 }, -- Azeroth's Undying Gift
+			[22] = { 0.40, 0 }, -- Vision of Perfection
 			[15] = { 0.56, 0 }, -- Ripple in Space
-			[27] = { 10, 5.63 }, -- Memory of Lucid Dreams
+			[27] = { 1.50, 0.70 }, -- Memory of Lucid Dreams
 		}, 1564822800)
 
 		insertDefaultScalesData(defensiveName, 11, 3, { -- Guardian Druid (TMI)


### PR DESCRIPTION
Greetings,

I'm one of the people doing the maths for all things BDK; over the past couple of days we had a number of people come in on Acherus asking why the weights given by your addon are drastically different to the weights we typically recommend. I've come with this PR in an attempt to at least provide a ballpark figure for the "real" defensive weights of essences and traits, along with an explanation as to why they were so wrong to start with.

You've done your numbers using simc and checked TMI. The problem with the entire TMI part of simc is twofold:

1. When you did your sims, I am pretty sure you used the mythic raid boss, which currently does a whopping 2k DTPS to the tank
2. Even if you had used simc's highest DTPS target (the TMI boss), it only AAs for 40k every 2s. This would not be enough to even bring you above the minimum death strike

Both of those have the same effect on essences and traits - those that modify death strike quantitywill have **massively amplified** value, seeing as you'll get 7% no matter what. Those that modify secondaries will, comparatively, be left in the dust, and the traits that provide major HPS (impassive visage being the best example - it's 2.5k HPS at the moment per trait, arguably the best on the ring, yet valued at 0.1 on your addon defensively) will end up in 99% overheal. After all, how useful is a 10k heal when 8.5k of it goes into overheal?

So. The changes:

1. Lucid dreams suffers from problem 1, as it increases the quantity of death strikes you'll be able to pump out by a factor of two over 15s. In practice it is very lackluster; its minor is even more so, providing 2 runes per minute
2. Crucible cannot be cast defensively by simcraft. As such, its "TMI weight" would be zero; in practice it is actually pretty good
3. Anima is noticeably less good for the same reason, but in reverse; after all, if it heals you for the 5% you have missing and only overheals by 50% of its heal (vs. 85% for IV) it'd massively rank better on TMI versus a low-damage target
4. Sphere's value is more of a case of its DTPS reduction is massively amplified by the low DTPS compared to the rest
5. Strife should be simmed at rank 2, not rank 1. Same with Aegis. You'll see that they both massively benefit from their "amplified" effects versus a boss that does more than 2k DTPS
6. AUG is massively better than 0, both on the major and the minor. It's not a good de facto essence still, but it is way better than zero. The reason it went to zero is because it isn't implemented at all in the simc version you used
7. Vision is comparatively worse; I've reduced its weight to something closer to its real value.

Traits-wise, it's similar issues:
- Marrowblood, bones and runeblade got massively overqualified for the RP or healing they provide. In practice, against a boss that actually does a more considerable amount of damage, crit traits will literally leave them in the dust, as would ERW.
- Impassive visage was completely missed out
- Vamp Speed does not proc on simc at all as mobs do not trigger their on-death, and there are no deaths on 1 target patchwerk. Consider adding a mythic+ mode. In practice, almost all encounters have adds of some sort (fun fact, it also procs from friendly deaths)
- ERW might be good but it's still not better than swirling sands or blightborne, even defensively. The crit these traits provide at 430 is stronger than DRW itself.

If you'd like to talk about this, you can catch me at @Mandl#0001 on discord or on Acherus, where I'm in charge of the blood channel. Always open for chat :-)

Take care